### PR TITLE
Update to Cocaine::CommandLine#run with interpolations

### DIFF
--- a/lib/miro/dominant_colors.rb
+++ b/lib/miro/dominant_colors.rb
@@ -43,15 +43,15 @@ module Miro
     def downsample_colors_and_convert_to_png!
       @source_image = open_source_image
       @downsampled_image = open_downsampled_image
-      command.run
+      command
     end
 
     def command
-      Cocaine::CommandLine.new(Miro.options[:image_magick_path], ":in -resize :resolution -colors :colors :out",
-                              :in => File.expand_path(@source_image.path),
-                              :resolution => Miro.options[:resolution],
-                              :colors => Miro.options[:color_count].to_s,
-                              :out => File.expand_path(@downsampled_image.path))
+      line = Cocaine::CommandLine.new(Miro.options[:image_magick_path], ":in -resize :resolution -colors :colors :out")
+      line.run(:in => File.expand_path(@source_image.path),
+                   :resolution => Miro.options[:resolution],
+                   :colors => Miro.options[:color_count].to_s,
+                   :out => File.expand_path(@downsampled_image.path))
     end
 
     def open_source_image

--- a/spec/miro/dominant_colors_spec.rb
+++ b/spec/miro/dominant_colors_spec.rb
@@ -56,12 +56,7 @@ describe Miro::DominantColors do
 
     it "runs the imagemagick command line with the correct arguments" do
       subject.stub(:open_downsampled_image).and_return(mock_downsampled_image)
-      Cocaine::CommandLine.should_receive(:new).with(Miro.options[:image_magick_path],
-                                                     ":in -resize :resolution -colors :colors :out",
-                                                     :in => '/path/to/source_image',
-                                                     :resolution => Miro.options[:resolution],
-                                                     :colors => Miro.options[:color_count].to_s,
-                                                     :out => '/path/to/downsampled_image')
+      Cocaine::CommandLine.should_receive(:new).with(Miro.options[:image_magick_path], ":in -resize :resolution -colors :colors :out")
       subject.sorted_pixels
     end
 


### PR DESCRIPTION
With this commit, https://github.com/thoughtbot/cocaine/commit/ec9efa2249d958f368c6baac5a8ca5042a475c3d, the interpolations are now passed to `command` and `run` instead as a hash of options to `new`.

Without this, I receive:

```
convert: unable to open image `in': No such file or directory @ error/blob.c/OpenBlob/2614.
convert: no decode delegate for this image format `in' @ error/constitute.c/ReadImage/532.
convert: invalid argument for option `-resize': :resolution @ error/convert.c/ConvertImageCommand/2355.
Cocaine::ExitStatusError: Command '/usr/local/bin/convert :in -resize :resolution -colors :colors :out' returned 1. Expected 0
```

Which is the original command without the interpolations.
