### PR TITLE
Fixes Issues with Tempfile

### DIFF
--- a/lib/miro/dominant_colors.rb
+++ b/lib/miro/dominant_colors.rb
@@ -62,6 +62,7 @@ module Miro
         remote_file_data = open(@src_image_path).read
 
         tempfile.write(RUBY_VERSION =~ /1.9/ ? remote_file_data.force_encoding("UTF-8") : remote_file_data)
+        tempfile.close
         return tempfile
       else
         return File.open(@src_image_path)


### PR DESCRIPTION
Tempfile should be closed before returning.
This fixes issues with small images that are not written to disc,
cause file is not closed.
