### PR TITLE
Calling #dup on RUBY_VERSION since it is a frozen string.

### DIFF
--- a/lib/miro/dominant_colors.rb
+++ b/lib/miro/dominant_colors.rb
@@ -69,7 +69,7 @@ module Miro
     end
 
     def should_force_encoding?
-      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9')
+      Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('1.9')
     end
 
     def open_downsampled_image


### PR DESCRIPTION
On all the systems we've tested this on, RUBY_VERSION is a frozen string.  As a result, we were getting `RuntimeError`s when using `Miro::DominantColors.new`.  
