### PR TITLE
Refactor variable name

### DIFF
--- a/lib/miro/dominant_colors.rb
+++ b/lib/miro/dominant_colors.rb
@@ -8,15 +8,15 @@ module Miro
     end
 
     def to_hex
-      sorted_pixels.collect {|c| ChunkyPNG::Color.to_hex c, false }
+      sorted_pixels.collect { |pixel| ChunkyPNG::Color.to_hex(pixel, false) }
     end
 
     def to_rgb
-      sorted_pixels.collect {|c| ChunkyPNG::Color.to_truecolor_bytes c }
+      sorted_pixels.collect { |pixel| ChunkyPNG::Color.to_truecolor_bytes(pixel) }
     end
 
     def to_rgba
-      sorted_pixels.collect {|c| ChunkyPNG::Color.to_truecolor_alpha_bytes c }
+      sorted_pixels.collect { |pixel| ChunkyPNG::Color.to_truecolor_alpha_bytes(pixel) }
     end
 
     def by_percentage


### PR DESCRIPTION
I don't like the name of the variable because `ChunkyPNG` is expecting a `color` but you're using `pixel` in this block:

``` ruby
sorted_pixels.collect { |pixel| @grouped_pixels[pixel].size / pixel_count.to_f }
```

So I've used the same name for the sake of consistency.
