### PR TITLE
Jruby Support

### DIFF
--- a/lib/miro.rb
+++ b/lib/miro.rb
@@ -1,9 +1,9 @@
 require "miro/version"
-require "oily_png"
 require "cocaine"
 require "color"
 require "tempfile"
 require "open-uri"
+require png_lib = (RUBY_ENGINE != "jruby" ? "oily_png" : "chunky_png") # Load the C extension oily_png unless jruby is the platform in use.
 
 require "miro/dominant_colors"
 

--- a/lib/miro/dominant_colors.rb
+++ b/lib/miro/dominant_colors.rb
@@ -63,7 +63,7 @@ module Miro
 
     def parse_result(hstring)
       hstring.scan(/(\d*):.*(#[0-9A-Fa-f]*)/).collect do |match|
-        [match[0].to_i, Object.const_get("Color::#{Miro.options[:quantize].upcase}").from_html(match[1])]
+        [match[0].to_i, eval("Color::#{Miro.options[:quantize].upcase}").from_html(match[1])]
       end
     end
 

--- a/lib/miro/version.rb
+++ b/lib/miro/version.rb
@@ -1,3 +1,3 @@
 module Miro
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/miro.gemspec
+++ b/miro.gemspec
@@ -11,8 +11,9 @@ Gem::Specification.new do |gem|
   gem.requirements  = 'ImageMagick'
 
   gem.add_dependency "cocaine"
-  gem.add_dependency "oily_png"
   gem.add_dependency "color"
+  gem.add_dependency "chunky_png"
+  gem.add_dependency "oily_png" if RUBY_ENGINE != "jruby"
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "fakeweb"


### PR DESCRIPTION
Due to the use of the C extension gem oily_png, Miro will not work on Jruby.

- If the ruby platform is jruby, do not require oily_png
- Use eval in place of Object.const_get (without this, 14 specs will fail)
- Version bumped to 0.4.0

Specs tested and passed on MRI 2.2.2, Rubinius 2.5.2 and Jruby 1.7.19.

