### PR TITLE
Color gem expects 6 character hex string

### DIFF
--- a/lib/miro/dominant_colors.rb
+++ b/lib/miro/dominant_colors.rb
@@ -113,7 +113,7 @@ module Miro
 
     def image_magick_params
       if Miro.histogram?
-        "':in[0]' -resize :resolution -colors :colors -colorspace :quantize -quantize :quantize -alpha remove -format %c histogram:info:"
+        "':in[0]' -resize :resolution -colors :colors -colorspace :quantize -quantize :quantize -alpha remove -alpha off -format %c histogram:info:"
       else
         "':in[0]' -resize :resolution -colors :colors -colorspace :quantize -quantize :quantize :out"
       end


### PR DESCRIPTION
Similar to #32 but deals with unwanted alpha channel info on osx. 

The color gem expects hex color string with 3 or 6 digits, see:
https://github.com/halostatue/color/blob/2159ca233851ca3304414b831d9da368dcbafb04/lib/color/rgb.rb#L609

When miro generates a histogram it uses `Color::RGB.from_html` however
image magick can generate 8 character hex string on osx where the image
contains an alpha channel.
Using these and `from_html` raises an error.

The PR tell image magick we want to discard the alpha channel info color strings